### PR TITLE
Add first iteration of the ability to parse multiple queries in a batch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test-once": "jest --coverage --config=configs/jest.json",
     "build": "tsc --watch",
     "build-once": "tsc",
-    "bundle": "rollup dist/main.js --file dist/bundle.js --format umd --name cackle"
+    "bundle": "rollup dist/main.js --file dist/bundle.js --format umd --name cackle",
+    "run": "nodemon dist/main.js",
+    "run-once": "node dist/main.js"
   },
   "repository": {
     "type": "git",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,58 @@
 import gql from 'graphql-tag';
-// import { graphql, GraphQLSchema, GraphQLObjectType, GraphQLString } from 'graphql';
+import { graphql, GraphQLSchema, GraphQLObjectType, GraphQLString } from 'graphql';
 import { print } from 'graphql/language/printer';
 import _ from 'lodash';
 
-// const schema = new GraphQLSchema({
-//   query: new GraphQLObjectType({
-//     name: 'RootQueryType',
-//     fields: {
-//       hello: {
-//         type: GraphQLString,
-//         resolve() {
-//           return 'world';
-//         },
-//       },
-//     },
-//   }),
-// });
+const otherThingType = new GraphQLObjectType({
+  name: 'otherThing',
+  fields: {
+    moreTest: {
+      type: GraphQLString,
+    },
+  },
+});
+
+const testType = new GraphQLObjectType({
+  name: 'test',
+  fields: {
+    thing: {
+      type: GraphQLString,
+    },
+    thing2: {
+      type: GraphQLString,
+    },
+    otherThing: {
+      type: otherThingType,
+    },
+  },
+});
+
+const schema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'RootQueryType',
+    fields: {
+      hello: {
+        type: GraphQLString,
+        resolve() {
+          return 'world';
+        },
+      },
+      test: {
+        name: 'test',
+        type: testType,
+        resolve() {
+          return {
+            thing: 'thing',
+            thing2: 'thing2',
+            otherThing: {
+              moreTest: 'otherThing moreTest',
+            },
+          };
+        },
+      },
+    },
+  }),
+});
 
 const createDeepNames = (selections: any[]): any[] => {
   return _.flatMap(selections, selection => {
@@ -27,13 +64,30 @@ const createDeepNames = (selections: any[]): any[] => {
   });
 };
 
+const createDeepAliases = (selections: any[]): any[] => {
+  return _.flatMap(selections, selection => {
+    const selectionSet = selection.selectionSet;
+    const alias = _.get(selection, 'alias.value', selection.name.value);
+    if (!selectionSet) {
+      return alias;
+    }
+    return _.map(createDeepAliases(selectionSet.selections), childAlias => alias + '.' + childAlias);
+  });
+};
+
+// TODO: Clean this up to be done in one loop
+const createDeepNamesAndAliases = (selections: any[]): { deepNames: any[]; deepAliases: any[] } => ({
+  deepNames: _.map(selections, createDeepNames),
+  deepAliases: _.map(selections, createDeepAliases),
+});
+
 const printObjectQuery = (objectQuery: any): string => `{
   ${_.join(_.map(objectQuery, (value, key) => (value === '' ? key : `${key} ${printObjectQuery(value)}`)), '\n')}
 }`;
 
 let Requests: Array<{ AST: any; resolve: (val?: any) => void; reject: (val?: any) => void }> = [];
 
-export const createQuery = async (query: any) => {
+export const createQuery = async (query: any) =>
   new Promise((resolve, reject) => {
     Requests.push({
       AST: gql(query),
@@ -41,7 +95,6 @@ export const createQuery = async (query: any) => {
       reject,
     });
   });
-};
 
 const firstQuery = `
   query {
@@ -65,8 +118,12 @@ const secondQuery = `
   }
 `;
 
-createQuery(firstQuery);
-createQuery(secondQuery);
+const createQueries = async () => {
+  const firstPromise = createQuery(firstQuery);
+  const secondPromise = createQuery(secondQuery);
+  const finalResult = await Promise.all([firstPromise, secondPromise]);
+  console.log(JSON.stringify(finalResult, null, 2));
+};
 
 const processQueries = async () => {
   const queryDefinitionGroups = _.map(Requests, ({ AST }) => {
@@ -81,12 +138,13 @@ const processQueries = async () => {
     }),
   );
   console.log(selections);
-  const deepNames = _.map(selections, createDeepNames);
+  const { deepNames, deepAliases } = createDeepNamesAndAliases(selections);
   console.log('DEEP NAMES:\n', deepNames);
-  const uniqueNames = _.uniq(...deepNames);
+  console.log('DEEP ALIASES:\n', deepAliases);
+  const uniqueNames = _.uniq(_.flatten(deepNames));
+  console.log('Unique Names:\n', uniqueNames);
   const newQueryObject = {};
   _.each(uniqueNames, uniqueName => _.set(newQueryObject, uniqueName, ''));
-  console.log(JSON.stringify(deepNames, null, 2));
   console.log(newQueryObject);
   const newQuery = printObjectQuery(newQueryObject);
   const finalAST = gql(newQuery);
@@ -94,7 +152,22 @@ const processQueries = async () => {
 
   console.log('\nQUERY:\n', query);
 
+  const response = await graphql(schema, query);
+  const result = response.data;
+  console.log(JSON.stringify(result, null, 2));
+
+  _.each(deepNames, (deepNameGroup, index) => {
+    const deepAliasGroup = deepAliases[index];
+    const returnObj = {};
+    _.each(deepAliasGroup, (deepAlias, aliasIndex) => {
+      const deepName = deepNameGroup[aliasIndex];
+      _.set(returnObj, deepAlias, _.get(result, deepName));
+    });
+    Requests[index].resolve(returnObj);
+  });
+
   Requests = [];
 };
 
+createQueries();
 processQueries();


### PR DESCRIPTION
Run by:
`npm run build-once && npm run run-once`

This is the first pass at getting a group of queries to be requested as one query... Anything that is queried for multiple times will only be included once in the request.

The example queries I used are:
```typescript
const firstQuery = `
  query {
    hello
    hello2: hello
    test {
      thing
    }
  }
`;
const secondQuery = `
  {
    hello
    test2: test {
      thing
      thing2
      otherThing {
        moreTest
      }
    }
  }
`;
```
And the resulting query that gets executed and has its result passed back to each individual request is:
```graphql
{
  hello
  test {
    thing
    thing2
    otherThing {
      moreTest
    }
  }
}
```